### PR TITLE
Adding configuration content

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,15 @@ installation.
 
 1. Clone this repository.
 2. Define the configuration file in './config/tsc-dashboard.ini'
-3. Execute the script 'source config.sh'. This script will execute the configuration 
-of the env and modify the file 'dashboard.py' in order to allow the automatic execution 
-of the python file. Last but not least, it moves the configuration file (tsc-dashboard.ini) 
-to the directory '/etc/fiware.d'
-4. Define your Google Credential in the './config/dashboard-credential.json' file.
-5. Define your Google service account key in the './config' directory
+3. Create your Google Credential in the './config/dashboard-credential.json' file.
+4. Create your Google service account key in the './config' directory
+5. Define owners.json file in the './config' directory.
+6. Execute the script 'source config.sh'. 
+7. With root user, execute the command 'cp ./config/tsc-dashboard.logrotate /etc/logrotate.d/tsc-dashboard
+
+This script (config.sh) will execute the configuration of the python virtualenv and 
+modify the file 'dashboard.py' in order to allow the automatic execution of the 
+python file. 
 
 Please, take a look to the https://console.developers.google.com in order to know more details 
 about the configuration of the credential for your application. Now the system is ready to use. 
@@ -44,7 +47,7 @@ You do not need to activate the virtualenv. The scripts will do it for you.
 
 [Top](#top)
 
-## Configuration
+### Configuration
 
 The script is searching the configuration parameters or in the '/etc/fiware.d'
 directory or in the environment variables. Firstly, The script try to find if there 
@@ -52,6 +55,19 @@ is defined an environment variable whose name is 'TSC_DASHBOARD_SETTINGS_FILE'.
 If the script cannot get this environment variable, it tries to find the file 
 'tsc-dashboard.ini' in '/etc/init.d' directory. In any oder case or the file does 
 not exist, the scripts will give you an error.
+
+## Run
+
+To execute the scripts, you only need to execute the following command:
+
+$ ./dashboard.py --noauth_local_webserver
+
+The first time that you execute it, you will be requested to provide access and write
+a verification code for your application. The following ones, you do not need to 
+repeat this process again.
+
+Keep in mind that the config.sh script modify the crontab file, therefore the application
+will be executed every working day at 4 o'clock.
 
 [Top](#top)
 

--- a/config.sh
+++ b/config.sh
@@ -1,1 +1,107 @@
 #!/usr/bin/env bash
+##
+# Copyright 2017 FIWARE Foundation, e.V.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+##
+
+
+
+# Initializing variables
+
+PYTHON_FILE="dashboard.py"
+INITIAL_HEADER="#\!\/usr\/bin\/env python"
+FINAL_HEADER='#\!\/usr\/bin\/env '
+VIRTUALENV_DIR='\/env\/bin\/python'
+
+
+
+# 1) Install&Config virtualenv for DesksReminder
+if [ ! -d "env" ]; then
+  # Control will enter here if env does not exist.
+  virtualenv -p python2.7 env
+
+  source env/bin/activate
+  pip install -r requirements.txt
+
+  deactivate
+fi
+
+
+
+# 2) Configure dashboard.py file
+
+working_directory=${PWD}
+
+result=$(echo ${working_directory} | sed 's@/@\\/@g')
+
+FINAL_HEADER=${FINAL_HEADER}${result}${VIRTUALENV_DIR}
+
+sed -i -e "s/${INITIAL_HEADER}/${FINAL_HEADER}/" ${PYTHON_FILE}
+
+chmod 744 ${PYTHON_FILE}
+
+
+
+# 3) Configure logrotate
+
+# Take the file and generate the proper content based on installation
+PATH_TO_CHANGE='\/logs\/tsc-dashboard\.log'
+NEW_PATH=${result}${PATH_TO_CHANGE}
+
+sed -i -e "s/${PATH_TO_CHANGE}/${NEW_PATH}/" ./config/tsc-dashboard.logrotate
+
+echo ""
+echo ""
+echo "Please, with root user, execute the following command:"
+echo ""
+echo "cp ./config/tsc-dashboard.logrotate /etc/logrotate.d/tsc-dashboard"
+echo ""
+echo ""
+
+
+
+# 4) configure crontab
+username=$(whoami)
+result=$(crontab -u ${username} -l 2>/dev/null)
+
+if [ "$result" == "" ]; then
+    if [ -e /tmp/cronlock ]; then
+        echo "cronjob locked"
+        exit 1
+    fi
+
+    touch /tmp/cronlock
+
+    echo "# FIWARE TSC Enabler Dashboard" | crontab -
+    (crontab -l; echo "00 4 * * mon-fri "${working_directory}"/dashboard.py --noauth_local_webserver") | crontab -
+
+    rm -f /tmp/cronlock
+
+else
+    crontab -u ${username} -l 2>/dev/null >a.out
+
+    touch /tmp/cronlock
+
+    line=$(grep "00 4 * * mon-fri "${working_directory}"/dashboard.py --noauth_local_webserver" a.out)
+    if [ "$line" == "" ]; then
+        (crontab -l; echo "") | crontab -
+        (crontab -l; echo "# FIWARE TSC Enabler Dashboard") | crontab -
+        (crontab -l; echo "00 4 * * mon-fri "${working_directory}"/dashboard.py --noauth_local_webserver") | crontab -
+    fi
+
+    rm -f /tmp/cronlock
+
+    rm a.out
+fi

--- a/config/tsc-dashboard.logrotate
+++ b/config/tsc-dashboard.logrotate
@@ -1,0 +1,11 @@
+su fla fla
+
+/logs/tsc-dashboard.log {
+        size 1k
+        copytruncate
+        create 664 fla fla
+        dateext
+        rotate 4
+        compress
+        missingok
+}

--- a/dashboard.py
+++ b/dashboard.py
@@ -121,7 +121,7 @@ class Dashboard:
 
 
 if __name__ == "__main__":
-    logger.info("Initilaizing the script...")
+    logger.info("Initializing the script...")
     dashboard = Dashboard()
 
     logger.info("Cleaning the Google Excel file...")

--- a/kernel/google.py
+++ b/kernel/google.py
@@ -23,9 +23,10 @@ from apiclient import discovery
 from oauth2client import client
 from oauth2client import tools
 from oauth2client.file import Storage
-from config.settings import CREDENTIAL, SERVICE_ACCOUNT_KEY, SERVICE_ACCOUNT_KEY_HOME
+from config.settings import CREDENTIAL, SERVICE_ACCOUNT_KEY, SERVICE_ACCOUNT_KEY_HOME, CODE_HOME
 from config.constants import APPLICATION_NAME, CREDENTIAL_DIR, CREDENTIAL_FILE
 from oauth2client.service_account import ServiceAccountCredentials
+from config.log import logger
 
 try:
     import argparse
@@ -46,16 +47,24 @@ def get_credentials(api):
     :return:
         Credentials, the obtained credential.
     """
+    logger.info("Get Google credential for API {}".format(api))
+
     # If modifying these scopes, delete your previously saved credentials
     # at ./.credentials/sheets.googleapis.com.json
     scope = {'sheets': 'https://www.googleapis.com/auth/spreadsheets',
              'analytics': 'https://www.googleapis.com/auth/analytics.readonly',
              'analyticsreporting': 'https://www.googleapis.com/auth/analytics.readonly'}
 
-    if not os.path.exists(CREDENTIAL_DIR):
-        os.makedirs(CREDENTIAL_DIR)
+    credential_folder = os.path.join(CODE_HOME, CREDENTIAL_DIR)
+    logger.debug("Credential dir: {}".format(credential_folder))
 
-    credential_path = os.path.join(CREDENTIAL_DIR, CREDENTIAL_FILE)
+    if not os.path.exists(credential_folder):
+        try:
+            os.makedirs(credential_folder)
+        except OSError as e:
+            logger.error("Unable to create the corresponding directory: {}".format(e.message))
+
+    credential_path = os.path.join(credential_folder, CREDENTIAL_FILE)
 
     if api == 'sheets':
         store = Storage(credential_path)
@@ -75,6 +84,8 @@ def get_credentials(api):
 
 
 def get_service(api_name):
+    logger.info("Get Google service for API {}".format(api_name))
+
     service = {'sheets': 'v4', 'analytics': 'v3', 'analyticsreporting': 'v4'}
     discoveryServiceUrl = {
         'sheets': 'https://sheets.googleapis.com/$discovery/rest?version=v4',


### PR DESCRIPTION
#### REVIEWER
@jicarretero 

#### DESCRIPTION
- Add shell script to configure the installation process.
- Update the README content
- Add pre-defined logrotate configuration file (to be configured during the execution of the config.sh script).
- Resolve absolute path to obtain google credential from .credential directory

#### TESTING
Remotelly.